### PR TITLE
Add support for Faraday's updated middleware_registry interface.

### DIFF
--- a/lib/faraday/conductivity.rb
+++ b/lib/faraday/conductivity.rb
@@ -13,11 +13,12 @@ require "faraday/conductivity/selective_errors"
 module Faraday
   module Conductivity
   end
-  register_middleware :middleware,  :extended_logging => Faraday::Conductivity::ExtendedLogging
-  register_middleware :request,     :user_agent       => Faraday::Conductivity::UserAgent
-  register_middleware :request,     :request_id       => Faraday::Conductivity::RequestId
-  register_middleware :request,     :mimetype         => Faraday::Conductivity::Mimetype
-  register_middleware :middleware,  :repeater         => Faraday::Conductivity::Repeater
-  register_middleware :response,    :selective_errors => Faraday::Conductivity::SelectiveErrors
+
+  Faraday::Middleware.register_middleware :extended_logging => Faraday::Conductivity::ExtendedLogging
+  Faraday::Middleware.register_middleware :repeater         => Faraday::Conductivity::Repeater
+  Faraday::Request.register_middleware    :mimetype         => Faraday::Conductivity::Mimetype
+  Faraday::Request.register_middleware    :request_id       => Faraday::Conductivity::RequestId
+  Faraday::Request.register_middleware    :user_agent       => Faraday::Conductivity::UserAgent
+  Faraday::Response.register_middleware   :selective_errors => Faraday::Conductivity::SelectiveErrors
 end
 


### PR DESCRIPTION
Faraday dropped the `Faraday.register_middleware` interface with the 0.9 release.  This switches the registrations to use the object registrations available in Faraday 0.8 and 0.9.

Support was not added for Faraday 0.7 since the current gemspec of this library is 0.8+.

This fixes issue #1.
