### PR TITLE
Add ability to set X-Request-Id via argument, not just thread variable

### DIFF
--- a/lib/faraday/conductivity/request_id.rb
+++ b/lib/faraday/conductivity/request_id.rb
@@ -2,12 +2,13 @@ module Faraday
   module Conductivity
     class RequestId < Faraday::Middleware
 
-      def initialize(app)
+      def initialize(app, request_id = nil)
         super(app)
+        @request_id = request_id
       end
 
       def call(env)
-        request_id = Thread.current[:request_id]
+        request_id = @request_id || Thread.current[:request_id]
         if request_id
           env[:request_headers]['X-Request-Id'] ||= request_id
         end

--- a/spec/middleware/request_id_spec.rb
+++ b/spec/middleware/request_id_spec.rb
@@ -2,20 +2,42 @@ RSpec.describe Faraday::Conductivity::RequestId do
 
   subject(:request_headers) { response.env[:request_headers] }
 
-  it "includes the thread local variable" do
-    Thread.current[:request_id] = "my-request-id"
-    expect(request_headers["X-Request-Id"]).to eq "my-request-id"
-  end
+  context "when request_id is set via thread variable" do
+    after { Thread.current[:request_id] = nil }
 
-  it "doesn't add the header if there is no request id" do
-    Thread.current[:request_id] = nil
-    expect(request_headers).not_to have_key "X-Request-Id"
-  end
+    it "includes the thread local variable" do
+      Thread.current[:request_id] = "my-request-id"
+      expect(request_headers["X-Request-Id"]).to eq "my-request-id"
+    end
 
-  def connection
-    create_connection do |faraday|
-      faraday.request :request_id
+    def connection
+      create_connection do |faraday|
+        faraday.request :request_id
+      end
     end
   end
 
+  context "when request id is set via second argument" do
+    it "includes the second argument" do
+      expect(request_headers["X-Request-Id"]).to eq "my-request-id"
+    end
+
+    def connection
+      create_connection do |faraday|
+        faraday.request :request_id, "my-request-id"
+      end
+    end
+  end
+
+  context "when request id is not set" do
+    it "doesn't add the header if there is no request id" do
+      expect(request_headers).not_to have_key "X-Request-Id"
+    end
+
+    def connection
+      create_connection do |faraday|
+        faraday.request :request_id
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hi

I suppose it could be useful feature. For example, I make requests to internal services in my background workers, and it would be much easier to explicitly set X-Request-Id via 2nd argument rather than to set Thread variable.
